### PR TITLE
hotfix in security.py

### DIFF
--- a/nipyapi/security.py
+++ b/nipyapi/security.py
@@ -409,6 +409,8 @@ def create_access_policy(resource, action, r_id=None, service='nifi'):
     assert service in _valid_services
     if resource[0] != '/':
         resource = '/' + resource
+    if resource[len(resource)-1] != '/':
+        resource = resource + '/'
     try:
         if service == 'nifi':
             return nipyapi.nifi.PoliciesApi().create_access_policy(
@@ -416,7 +418,7 @@ def create_access_policy(resource, action, r_id=None, service='nifi'):
                     revision=nipyapi.nifi.RevisionDTO(version=0),
                     component=nipyapi.nifi.AccessPolicyDTO(
                         action=action,
-                        resource=resource + '/' + r_id
+                        resource=resource + r_id
                     )
                 )
             )


### PR DESCRIPTION
We ran into an issue when attemping to create a global policy for viewing system diagnostics.

We attempted to call the api with the following line:
system_policy = nipyapi.security.create_access_policy(resource="/", action="read", r_id="system", service="nifi")

The issue here is that it creates a policy in nifi that has 2 slashes (//).
E.G. "policy identifier="xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" resource="//system" action="R""
it should read 
"policy identifier="xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" resource="/system" action="R""

By having a "/" get appended on line 419 regardless of if your resource[0] is a "/", you get this incorrect double slash when attempting to call this api to create a policy at the global level and not tied to a specific processor group, for example, attempting to allow user to view system diagnostics.

We added an additional check in lines 412-413 to still handle appending the "/" in cases where it doesn't exist (handling all prior use cases) but it also not will function correctly when creating a global policy.